### PR TITLE
improve CDATA Encoder to not emit intermediate characters

### DIFF
--- a/core/src/main/java/org/owasp/encoder/CDATAEncoder.java
+++ b/core/src/main/java/org/owasp/encoder/CDATAEncoder.java
@@ -40,10 +40,9 @@ import java.nio.charset.CoderResult;
  * CDATAEncoder -- encoder for CDATA sections. CDATA sections are generally good for including large blocks of text that contain
  * characters that normally require encoding (ampersand, quotes, less-than, etc...). The CDATA context however still does not
  * allow invalid characters, and can be closed by the sequence "]]>". This encoder removes invalid XML characters, and encodes
- * "]]>" (to "]]>]]&lt;![CDATA[>"). The result is that the data integrity is maintained, but the code receiving the output will
- * have to handle multiple CDATA events with character events between. As an alternate approach, the caller could pre-encode "]]>"
- * to something of their choosing (e.g. data.replaceAll("\\]\\]>", "]] >")), then use this encoder to remove any invalid XML
- * characters.
+ * "]]>" (to "]]]]>&lt;![CDATA[>"). The result is that the data integrity is maintained, but the code receiving the output will
+ * have to handle multiple CDATA events. As an alternate approach, the caller could pre-encode "]]>" to something of their 
+ * choosing (e.g. data.replaceAll("\\]\\]>", "]] >")), then use this encoder to remove any invalid XML characters.
  *
  * @author Jeff Ichnowski
  */
@@ -53,10 +52,10 @@ class CDATAEncoder extends Encoder {
      * The encoding of @{code "]]>"}.
      */
     private static final char[] CDATA_END_ENCODED
-            = "]]>]]<![CDATA[>".toCharArray();
+            = "]]]]><![CDATA[>".toCharArray();
 
     /**
-     * Length of {@code "]]>]]<![CDATA[>"}.
+     * Length of {@code "]]]]><![CDATA[>"}.
      */
     private static final int CDATA_END_ENCODED_LENGTH = 15;
 
@@ -69,8 +68,8 @@ class CDATAEncoder extends Encoder {
     protected int maxEncodedLength(int n) {
         // "]" becomes "]" (1 -> 1)
         // "]]" becomes "]]" (2 -> 2)
-        // "]]>" becomes "]]>]]<![CDATA[>" (3 -> 15)
-        // "]]>]" becomes "]]>]]<![CDATA[>]" (3 -> 15 + 1 -> 1)
+        // "]]>" becomes "]]]]><![CDATA[>" (3 -> 15)
+        // "]]>]" becomes "]]]]><![CDATA[>]" (3 -> 15 + 1 -> 1)
         // ...
 
         int worstCase = n / CDATA_END_LENGTH;

--- a/core/src/test/java/org/owasp/encoder/CDATAEncoderTest.java
+++ b/core/src/test/java/org/owasp/encoder/CDATAEncoderTest.java
@@ -45,12 +45,12 @@ import junit.framework.TestCase;
 public class CDATAEncoderTest extends TestCase {
     public static Test suite() {
         return new EncoderTestSuiteBuilder(CDATAEncoderTest.class, new CDATAEncoder(), "-safe-", "-]]>-")
-            .encode("]]>]]<![CDATA[>", "]]>")
+            .encode("]]]]><![CDATA[>", "]]>")
             .encode("]", "]")
             .encode("]]", "]]")
-            .encode("]]>]]<![CDATA[>]", "]]>]")
-            .encode("]]>]]<![CDATA[>]>", "]]>]>")
-            .encode("]]>]]<![CDATA[>>", "]]>>")
+            .encode("]]]]><![CDATA[>]", "]]>]")
+            .encode("]]]]><![CDATA[>]>", "]]>]>")
+            .encode("]]]]><![CDATA[>>", "]]>>")
             .encode("]]]]]", "]]]]]")
             .encode("<\"&\'>", "<\"&\'>") // valid in CDATA, not in XML
 


### PR DESCRIPTION
between adjacent CDATA sections.

The new behavior changes the encoding of the closing characters "]]>" in such a way that there are no intermediate character between both CDATA sections. This makes the output XML more efficient in a way that there are fewer (child) nodes, and all characters are wrapped within a CDATA-section (particular important if some XML consuming software requires all characters to be wrapped in CDATA...).