### PR TITLE
forHtmlAttribute example usage documentation correction

### DIFF
--- a/core/src/main/java/org/owasp/encoder/Encode.java
+++ b/core/src/main/java/org/owasp/encoder/Encode.java
@@ -236,7 +236,7 @@ public final class Encode {
      *
      * <b>Example JSP Usage</b>
      * <pre>
-     *     &lt;div&gt;&lt;%=Encode.forHtml(unsafeData)%&gt;&lt;/div&gt;
+     *     &lt;div&gt;&lt;%=Encode.forHtmlAttribute(unsafeData)%&gt;&lt;/div&gt;
      * </pre>
      *
      * <table border="0" class="memberSummary" summary="Shows the input and results of encoding">


### PR DESCRIPTION
In the API documentation, forHtmlAttribute method's example usage is listed as following.

<div><%=Encode.forHtml(unsafeData)%></div>

It is corrected as following in this pull request.

<div><%=Encode.forHtmlAttribute(unsafeData)%></div>

[1] https://owasp.github.io/owasp-java-encoder/encoder/apidocs/org/owasp/encoder/Encode.html#forHtmlAttribute-java.lang.String-