### PR TITLE
Changes to get owasp-java-encoder to work with ESAPI 2.2.0.0 and later

### DIFF
--- a/esapi/pom.xml
+++ b/esapi/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.owasp.esapi</groupId>
             <artifactId>esapi</artifactId>
-            <version>[2.0,3)</version>
+            <version>[2.2,3)</version>
         </dependency>
     </dependencies>
 </project>

--- a/esapi/src/main/java/org/owasp/encoder/esapi/ESAPIEncoder.java
+++ b/esapi/src/main/java/org/owasp/encoder/esapi/ESAPIEncoder.java
@@ -35,6 +35,7 @@
 package org.owasp.encoder.esapi;
 
 import java.io.IOException;
+import java.net.URI;
 import org.owasp.encoder.Encode;
 import org.owasp.esapi.Encoder;
 import org.owasp.esapi.codecs.Codec;
@@ -63,6 +64,7 @@ import org.owasp.esapi.reference.DefaultEncoder;
  *     {@link org.owasp.esapi.Encoder#canonicalize(String)},
  *     {@link org.owasp.esapi.Encoder#canonicalize(String, boolean)},
  *     {@link org.owasp.esapi.Encoder#canonicalize(String, boolean, boolean)}</li>
+ *     {@link org.owasp.esapi.Encoder#getCanonicalizedURI(URI)}</li>
  *
  *     <li>Decoding methods:
  *     {@link org.owasp.esapi.Encoder#decodeForHTML(String)},
@@ -80,6 +82,7 @@ import org.owasp.esapi.reference.DefaultEncoder;
  *     <li>Rarely-used or alternate compatible encoding:
  *     {@link org.owasp.esapi.Encoder#encodeForVBScript(String)},
  *     {@link org.owasp.esapi.Encoder#encodeForLDAP(String)},
+ *     {@link org.owasp.esapi.Encoder#encodeForLDAP(String, boolean)},
  *     {@link org.owasp.esapi.Encoder#encodeForDN(String)}</li>
  * </ul>
  *
@@ -153,6 +156,11 @@ public final class ESAPIEncoder {
         }
 
         /** {@inheritDoc} */
+        public String getCanonicalizedURI(URI dirtyUri) {
+            return _referenceEncoder.getCanonicalizedURI(dirtyUri);
+        }
+
+        /** {@inheritDoc} */
         public String encodeForCSS(String s) {
             return Encode.forCssString(s);
         }
@@ -198,6 +206,11 @@ public final class ESAPIEncoder {
         }
 
         /** {@inheritDoc} */
+        public String encodeForLDAP(String s, boolean b) {
+            return _referenceEncoder.encodeForLDAP(s, b);
+        }
+
+        /** {@inheritDoc} */
         public String encodeForDN(String s) {
             return _referenceEncoder.encodeForDN(s);
         }
@@ -236,5 +249,6 @@ public final class ESAPIEncoder {
         public byte[] decodeFromBase64(String s) throws IOException {
             return _referenceEncoder.decodeFromBase64(s);
         }
+
     }
 }

--- a/esapi/src/test/resources/.esapi/ESAPI.properties
+++ b/esapi/src/test/resources/.esapi/ESAPI.properties
@@ -1,1 +1,38 @@
+# Properties based on ESAPI 2.2.1.1's configuration/esapi/ESAPI.properties file.
+
 ESAPI.Encoder=org.owasp.encoder.esapi.ESAPIEncoder
+
+# Log4JFactory Requires log4j.xml or log4j.properties in classpath - http://www.laliluna.de/log4j-tutorial.html
+# Note that this is now considered deprecated!
+#ESAPI.Logger=org.owasp.esapi.logging.log4j.Log4JLogFactory
+
+# To use JUL, you need to obtain ESAPI's esapi-java-logging.properties and drop
+# it somewhere into your class path. You can get it from the ESAPI configuration
+# jar. (See Release 2.2.1.1 under GitHub for ESAPI/esapi-java-legacy.)
+
+#ESAPI.Logger=org.owasp.esapi.logging.java.JavaLogFactory
+# To use the new SLF4J logger in ESAPI (see GitHub issue #129), set
+ESAPI.Logger=org.owasp.esapi.logging.slf4j.Slf4JLogFactory
+# and do whatever other normal SLF4J configuration that you normally would do for your application.
+
+# Note: The uncommented out ones are those needed for SLF4J. Others may be
+# needed if you change the ESAPI logger.
+#===========================================================================
+# ESAPI Logging
+# Set the application name if these logs are combined with other applications
+Logger.ApplicationName=ESAPI-Shim-Test
+# If you use an HTML log viewer that does not properly HTML escape log data, you can set LogEncodingRequired to true
+Logger.LogEncodingRequired=false
+# Determines whether ESAPI should log the application name. This might be clutter in some single-server/single-app environments.
+Logger.LogApplicationName=true
+# Determines whether ESAPI should log the server IP and port. This might be clutter in some single-server environments.
+Logger.LogServerIP=false
+# LogFileName, the name of the logging file. Provide a full directory path (e.g., C:\\ESAPI\\ESAPI_logging_file) if you
+# want to place it in a specific directory.
+#Logger.LogFileName=ESAPI_logging_file
+# MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
+#Logger.MaxLogFileSize=10000000
+# Determines whether ESAPI should log the user info.
+Logger.UserInfo=false
+# Determines whether ESAPI should log the session id and client IP
+Logger.ClientInfo=false

--- a/esapi/src/test/resources/.esapi/ESAPI.properties
+++ b/esapi/src/test/resources/.esapi/ESAPI.properties
@@ -9,10 +9,10 @@ ESAPI.Encoder=org.owasp.encoder.esapi.ESAPIEncoder
 # To use JUL, you need to obtain ESAPI's esapi-java-logging.properties and drop
 # it somewhere into your class path. You can get it from the ESAPI configuration
 # jar. (See Release 2.2.1.1 under GitHub for ESAPI/esapi-java-legacy.)
+ESAPI.Logger=org.owasp.esapi.logging.java.JavaLogFactory
 
-#ESAPI.Logger=org.owasp.esapi.logging.java.JavaLogFactory
 # To use the new SLF4J logger in ESAPI (see GitHub issue #129), set
-ESAPI.Logger=org.owasp.esapi.logging.slf4j.Slf4JLogFactory
+#ESAPI.Logger=org.owasp.esapi.logging.slf4j.Slf4JLogFactory
 # and do whatever other normal SLF4J configuration that you normally would do for your application.
 
 # Note: The uncommented out ones are those needed for SLF4J. Others may be

--- a/esapi/src/test/resources/esapi-java-logging.properties
+++ b/esapi/src/test/resources/esapi-java-logging.properties
@@ -1,0 +1,6 @@
+handlers= java.util.logging.ConsoleHandler
+.level= INFO
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%3$-7s] %5$s %n
+#https://www.logicbig.com/tutorials/core-java-tutorial/logging/customizing-default-format.html


### PR DESCRIPTION
Close #31

Note that you will need to do an official release for this. I did not update your owasp-java-encoder version because I wasn't sure if you wanted to call it 1.2.3 or 1.3.0 or what.

**IMPORTANT NOTE** Your minimal JDK is 1.5. As of ESAPI 2.2, or minimal supported JDK is 1.7. Please make your users aware of that should they choose to use this never version of org.owasp.encoder:encoder-esapi