### PR TITLE
Add automatic module name

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -7,4 +7,3 @@ Bundle-Version: 1.2.1
 Created-By: 1.8.0_181 (Oracle Corporation)
 Export-Package: org.owasp.encoder
 Tool: Bnd-1.50.0
-Automatic-Module-Name: org.owasp.encoder

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -7,3 +7,4 @@ Bundle-Version: 1.2.1
 Created-By: 1.8.0_181 (Oracle Corporation)
 Export-Package: org.owasp.encoder
 Tool: Bnd-1.50.0
+Automatic-Module-Name: org.owasp.encoder

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,6 +56,10 @@
         Scripting.
     </description>
 
+    <properties>
+        <jigsaw.module.name>org.owasp.encoder</jigsaw.module.name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/esapi/pom.xml
+++ b/esapi/pom.xml
@@ -54,6 +54,10 @@
         Projects API into an implementation of ESAPI.
     </description>
 
+    <properties>
+        <jigsaw.module.name>org.owasp.encoder.esapi</jigsaw.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.owasp.encoder</groupId>

--- a/jsp/pom.xml
+++ b/jsp/pom.xml
@@ -55,6 +55,10 @@
         definitions and JSP EL functions.
     </description>
 
+    <properties>
+        <jigsaw.module.name>org.owasp.encoder.jsp</jigsaw.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.owasp.encoder</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,7 @@
                             <instructions>
                                 <_noee>true</_noee>
                                 <_nouses>true</_nouses>
+                                <Automatic-Module-Name>${jigsaw.module.name}</Automatic-Module-Name>
                             </instructions>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Hey, I'm using OWASP Java Encoder in my template engine (https://jte.gg).

I'm currently adding Java 9 modules to jte and noticed that OWASP Java Encoder does not yet have an automatic module name. This would allow me to reference the encoder in my module.info.

What do you think?

PS: Thanks for this awesome library, the `Writer` based escape methods are blazingly fast!