### PR TITLE
Tiny typo Fix

### DIFF
--- a/core/src/main/java/org/owasp/encoder/EncodedWriter.java
+++ b/core/src/main/java/org/owasp/encoder/EncodedWriter.java
@@ -39,7 +39,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.CoderResult;
 
 /**
- * EncodedWriter -- A writer the encodes all input for a specific context and writes the encoded output to another writer.
+ * EncodedWriter -- A writer that encodes all input for a specific context and writes the encoded output to another writer.
  *
  * @author Jeff Ichnowski
  */


### PR DESCRIPTION
Hey!

Here is a tiny typo fix, for the `EncodedWriter`'s Javadoc. I made a quick review of the rest and saw no other (obvious) typo.