### PR TITLE
General Maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ maven-eclipse.xml
 nb-configuration.xml
 */nbproject/*
 
+/jsp/target/
+/esapi/target/
+/target/

--- a/esapi/pom.xml
+++ b/esapi/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.owasp.esapi</groupId>
             <artifactId>esapi</artifactId>
-            <version>[2.2,3)</version>
+            <version>[2.2.3.1,3)</version>
         </dependency>
     </dependencies>
 </project>

--- a/jsp/src/main/java/org/owasp/encoder/tag/EncodingTag.java
+++ b/jsp/src/main/java/org/owasp/encoder/tag/EncodingTag.java
@@ -37,7 +37,7 @@ package org.owasp.encoder.tag;
 import javax.servlet.jsp.tagext.SimpleTagSupport;
 
 /**
- * The base class for the encoding tags within tihs package.
+ * The base class for the encoding tags within this package.
  *
  * @author Jeremy Long (jeremy.long@gmail.com)
  */

--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <source>1.8</source>
+                            <source>1.6</source>
                             <failOnError>false</failOnError>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -162,27 +162,27 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.10.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.2.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.6</version>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.8</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -266,8 +266,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -292,24 +292,17 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <configuration>
-                    <check>
-                        <branchRate>85</branchRate>
-                        <lineRate>85</lineRate>
-                        <haltOnFailure>false</haltOnFailure>
-                        <totalBranchRate>85</totalBranchRate>
-                        <totalLineRate>85</totalLineRate>
-                        <packageLineRate>85</packageLineRate>
-                        <packageBranchRate>85</packageBranchRate>
-                    </check>
-                </configuration>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>prepare-agent</id>
                         <goals>
-                            <goal>clean</goal>
+                            <goal>prepare-agent</goal>
                         </goals>
+                        <configuration>
+                            <propertyName>surefireArgLine</propertyName>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -320,7 +313,7 @@
                     <excludes>
                         <exclude>org/owasp/encoder/BenchmarkTest.java</exclude>
                     </excludes>
-                    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                    <argLine>${surefireArgLine}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -333,12 +326,6 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <skipIfEmpty>true</skipIfEmpty>
-                            <archive>
-                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                            </archive>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -365,6 +352,10 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <source>1.8</source>
+                            <failOnError>false</failOnError>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -424,8 +415,16 @@
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <!-- select non-aggregate reports -->
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -445,6 +444,10 @@
                         <reports>
                             <report>javadoc</report>
                         </reports>
+                        <configuration>
+                            <source>1.6</source>
+                            <failOnError>false</failOnError>
+                        </configuration>
                     </reportSet>
                 </reportSets>
             </plugin>


### PR DESCRIPTION
Due to encountering build issues locally - I had to upgrade several plugins and move from cobertura to jacoco for code coverage.

This PR does remove the support for java 1.5 with the new minimum version being 1.6.